### PR TITLE
Phase 1: Foundation -- dependencies, config paths, exceptions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,8 @@ google-auth-httplib2>=0.1.0
 platformdirs>=3.0.0
 tzdata>=2023.3
 urllib3>=2.0.0
+requests>=2.28.0
+azure-communication-email>=1.0.0
 
 # Development dependencies
 pytest>=7.0.0

--- a/tests/acceptance/test_nf.py
+++ b/tests/acceptance/test_nf.py
@@ -3,6 +3,7 @@
 import os
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -15,8 +16,6 @@ def test_nf1_existing_youtube_behavior_unchanged():
     All pre-existing unit and integration tests continue to pass,
     confirming no regression in YouTube-only functionality.
     """
-    # This test will be enabled in Phase 3 when --mode flag is added.
-    # It verifies that existing tests still pass after the integration.
     from youtube_updater.core.restream_client import RestreamClient
     pytest.fail("Restream integration not yet implemented -- NF1 verification deferred")
 
@@ -32,7 +31,6 @@ def test_nf2_restream_creds_0o600(temp_config_dir):
     pytest.fail("RestreamAuth not yet implemented")
 
 
-@pytest.mark.xfail(reason="Phase 1: not yet implemented", strict=True)
 def test_nf3_requests_in_requirements(project_root):
     """NF3: requests library added to requirements.txt.
 
@@ -44,7 +42,6 @@ def test_nf3_requests_in_requirements(project_root):
     assert "requests" in content, "requests not found in requirements.txt"
 
 
-@pytest.mark.xfail(reason="Phase 1: not yet implemented", strict=True)
 def test_nf4_youtube_auth_files_never_modified(temp_config_dir):
     """NF4: Never modify token.json, credentials.json, pickle.json.
 
@@ -52,5 +49,36 @@ def test_nf4_youtube_auth_files_never_modified(temp_config_dir):
     When: Restream and email config operations are performed
     Then: YouTube auth file mtimes are unchanged
     """
-    from youtube_updater.core.restream_auth import RestreamAuth
-    pytest.fail("RestreamAuth not yet implemented -- NF4 safeguard deferred")
+    from youtube_updater.core.config_manager import ConfigManager
+
+    # Create sentinel YouTube auth files
+    yt_auth_files = ["token.json", "credentials.json", "token.pickle"]
+    for name in yt_auth_files:
+        path = temp_config_dir / name
+        path.write_text("sentinel")
+
+    # Record mtimes
+    before = {}
+    for name in yt_auth_files:
+        path = temp_config_dir / name
+        before[name] = path.stat().st_mtime
+
+    # Small delay to ensure mtime would differ if written
+    time.sleep(0.05)
+
+    # Perform config operations that touch Restream/email paths
+    cm = ConfigManager(str(temp_config_dir))
+    _ = cm.get_restream_token_path()
+    cm.save_email_config({
+        "connection_string": "test",
+        "sender": "a@b.com",
+        "recipient": "c@d.com",
+    })
+    _ = cm.get_email_config()
+
+    # Verify YouTube auth files unchanged
+    for name in yt_auth_files:
+        path = temp_config_dir / name
+        assert path.stat().st_mtime == before[name], (
+            f"YouTube auth file {name} was modified by config operations"
+        )

--- a/tests/integration/test_config_restream.py
+++ b/tests/integration/test_config_restream.py
@@ -1,0 +1,54 @@
+"""Integration tests for ConfigManager Restream and email config with real file I/O."""
+
+import json
+import os
+
+from youtube_updater.core.config_manager import ConfigManager
+
+
+class TestConfigManagerRestreamIntegration:
+    """Real file I/O tests for ConfigManager Restream/email methods."""
+
+    def test_restream_token_path_resolves_under_config_dir(self, tmp_path):
+        cm = ConfigManager(str(tmp_path))
+        path = cm.get_restream_token_path()
+        assert os.path.dirname(path) == str(tmp_path)
+
+    def test_email_config_save_load_roundtrip(self, tmp_path):
+        cm = ConfigManager(str(tmp_path))
+        config = {
+            "connection_string": "endpoint=https://acs.azure.com/;key=abc123",
+            "sender": "noreply@example.com",
+            "recipient": "admin@example.com",
+        }
+        cm.save_email_config(config)
+
+        # Verify file exists and is valid JSON
+        email_path = tmp_path / "email_config.json"
+        assert email_path.exists()
+        with open(email_path) as f:
+            on_disk = json.load(f)
+        assert on_disk == config
+
+        # Load via ConfigManager
+        loaded = cm.get_email_config()
+        assert loaded == config
+
+    def test_email_config_overwrite(self, tmp_path):
+        cm = ConfigManager(str(tmp_path))
+        cm.save_email_config({"connection_string": "old", "sender": "a", "recipient": "b"})
+        cm.save_email_config({"connection_string": "new", "sender": "x", "recipient": "y"})
+        loaded = cm.get_email_config()
+        assert loaded["connection_string"] == "new"
+
+    def test_get_file_paths_includes_restream_token_with_correct_path(self, tmp_path):
+        cm = ConfigManager(str(tmp_path))
+        paths = cm.get_file_paths()
+        assert paths["restream_token_path"] == os.path.join(str(tmp_path), "restream_token.json")
+
+    def test_ensure_restream_token_false_then_true_after_write(self, tmp_path):
+        cm = ConfigManager(str(tmp_path))
+        assert cm.ensure_restream_token() is False
+        with open(cm.get_restream_token_path(), "w") as f:
+            json.dump({"access_token": "test"}, f)
+        assert cm.ensure_restream_token() is True

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -30,3 +30,75 @@ def test_get_file_paths_returns_correct_keys(tmp_path):
     assert "token_path" in paths
     assert "client_secrets_path" in paths
     assert "history_log" in paths
+
+
+# --- Phase 1: Restream + email config methods ---
+
+
+def test_get_restream_token_path_returns_path_under_config_dir(tmp_path):
+    cm = ConfigManager(str(tmp_path))
+    path = cm.get_restream_token_path()
+    assert str(tmp_path) in path
+    assert "restream_token.json" in path
+
+
+def test_get_restream_token_path_is_stable(tmp_path):
+    cm = ConfigManager(str(tmp_path))
+    assert cm.get_restream_token_path() == cm.get_restream_token_path()
+
+
+def test_ensure_restream_token_returns_false_when_missing(tmp_path):
+    cm = ConfigManager(str(tmp_path))
+    assert cm.ensure_restream_token() is False
+
+
+def test_ensure_restream_token_returns_true_when_exists(tmp_path):
+    cm = ConfigManager(str(tmp_path))
+    token_path = cm.get_restream_token_path()
+    with open(token_path, "w") as f:
+        f.write("{}")
+    assert cm.ensure_restream_token() is True
+
+
+def test_save_email_config_writes_file(tmp_path):
+    cm = ConfigManager(str(tmp_path))
+    config = {
+        "connection_string": "endpoint=...",
+        "sender": "noreply@example.com",
+        "recipient": "admin@example.com",
+    }
+    cm.save_email_config(config)
+    assert (tmp_path / "email_config.json").exists()
+
+
+def test_get_email_config_returns_none_when_missing(tmp_path):
+    cm = ConfigManager(str(tmp_path))
+    assert cm.get_email_config() is None
+
+
+def test_get_email_config_returns_saved_data(tmp_path):
+    cm = ConfigManager(str(tmp_path))
+    config = {
+        "connection_string": "endpoint=...",
+        "sender": "noreply@example.com",
+        "recipient": "admin@example.com",
+    }
+    cm.save_email_config(config)
+    loaded = cm.get_email_config()
+    assert loaded == config
+
+
+def test_get_file_paths_includes_restream_token(tmp_path):
+    cm = ConfigManager(str(tmp_path))
+    paths = cm.get_file_paths()
+    assert "restream_token_path" in paths
+
+
+def test_save_email_config_sets_0o600_permissions(tmp_path):
+    import os
+    import stat
+    cm = ConfigManager(str(tmp_path))
+    cm.save_email_config({"connection_string": "secret", "sender": "a", "recipient": "b"})
+    email_path = tmp_path / "email_config.json"
+    mode = stat.S_IMODE(os.stat(email_path).st_mode)
+    assert mode == 0o600, f"Expected 0o600 but got {oct(mode)}"

--- a/tests/unit/test_nf4_safeguard.py
+++ b/tests/unit/test_nf4_safeguard.py
@@ -1,0 +1,66 @@
+"""NF4 safeguard: verify that config operations never touch YouTube auth files."""
+
+import time
+
+import pytest
+
+from youtube_updater.core.config_manager import ConfigManager
+
+
+YOUTUBE_AUTH_FILES = ["token.json", "credentials.json", "token.pickle"]
+
+
+class TestNF4Safeguard:
+    """Verify that ConfigManager Restream/email methods never modify YouTube auth files."""
+
+    def test_get_restream_token_path_does_not_touch_yt_auth(self, tmp_path):
+        """get_restream_token_path() must not modify any YouTube auth file."""
+        for name in YOUTUBE_AUTH_FILES:
+            (tmp_path / name).write_text("sentinel")
+        before = {n: (tmp_path / n).stat().st_mtime for n in YOUTUBE_AUTH_FILES}
+        time.sleep(0.05)
+
+        cm = ConfigManager(str(tmp_path))
+        cm.get_restream_token_path()
+
+        for name in YOUTUBE_AUTH_FILES:
+            assert (tmp_path / name).stat().st_mtime == before[name]
+
+    def test_save_email_config_does_not_touch_yt_auth(self, tmp_path):
+        """save_email_config() must not modify any YouTube auth file."""
+        for name in YOUTUBE_AUTH_FILES:
+            (tmp_path / name).write_text("sentinel")
+        before = {n: (tmp_path / n).stat().st_mtime for n in YOUTUBE_AUTH_FILES}
+        time.sleep(0.05)
+
+        cm = ConfigManager(str(tmp_path))
+        cm.save_email_config({
+            "connection_string": "test",
+            "sender": "a@b.com",
+            "recipient": "c@d.com",
+        })
+
+        for name in YOUTUBE_AUTH_FILES:
+            assert (tmp_path / name).stat().st_mtime == before[name]
+
+    def test_get_email_config_does_not_touch_yt_auth(self, tmp_path):
+        """get_email_config() must not modify any YouTube auth file."""
+        for name in YOUTUBE_AUTH_FILES:
+            (tmp_path / name).write_text("sentinel")
+        before = {n: (tmp_path / n).stat().st_mtime for n in YOUTUBE_AUTH_FILES}
+        time.sleep(0.05)
+
+        cm = ConfigManager(str(tmp_path))
+        cm.get_email_config()
+
+        for name in YOUTUBE_AUTH_FILES:
+            assert (tmp_path / name).stat().st_mtime == before[name]
+
+    def test_restream_token_path_is_not_yt_auth_file(self, tmp_path):
+        """The Restream token path must not collide with YouTube auth file names."""
+        cm = ConfigManager(str(tmp_path))
+        restream_path = cm.get_restream_token_path()
+        filename = restream_path.split("/")[-1] if "/" in restream_path else restream_path.split("\\")[-1]
+        assert filename not in YOUTUBE_AUTH_FILES, (
+            f"Restream token filename '{filename}' collides with YouTube auth file"
+        )

--- a/youtube_updater/core/config_manager.py
+++ b/youtube_updater/core/config_manager.py
@@ -1,3 +1,4 @@
+import json
 import os
 from pathlib import Path
 from typing import Dict, Optional
@@ -33,14 +34,16 @@ class ConfigManager:
         self.token_path = os.path.join(self.config_dir, "token.json")
         self.client_secrets_path = os.path.join(self.config_dir, "client_secrets.json")
         self.history_log = os.path.join(self.config_dir, "history.log")
-        
+        self.restream_token_path = os.path.join(self.config_dir, "restream_token.json")
+        self.email_config_path = os.path.join(self.config_dir, "email_config.json")
+
         # Create empty files if they don't exist
         for file_path in [self.titles_file, self.applied_titles_file, self.history_log]:
             self.file_ops.ensure_file_exists(file_path)
     
     def get_file_paths(self) -> Dict[str, str]:
         """Get all file paths used by the application.
-        
+
         Returns:
             Dict[str, str]: Dictionary of file paths
         """
@@ -49,7 +52,8 @@ class ConfigManager:
             "applied_titles_file": self.applied_titles_file,
             "token_path": self.token_path,
             "client_secrets_path": self.client_secrets_path,
-            "history_log": self.history_log
+            "history_log": self.history_log,
+            "restream_token_path": self.restream_token_path,
         }
     
     def ensure_client_secrets(self) -> bool:
@@ -62,8 +66,46 @@ class ConfigManager:
     
     def get_client_secrets_path(self) -> str:
         """Get the path to the client secrets file.
-        
+
         Returns:
             str: Path to client secrets file
         """
-        return self.client_secrets_path 
+        return self.client_secrets_path
+
+    def get_restream_token_path(self) -> str:
+        """Get the path to the Restream token file.
+
+        Returns:
+            str: Path to restream_token.json
+        """
+        return self.restream_token_path
+
+    def ensure_restream_token(self) -> bool:
+        """Check if the Restream token file exists.
+
+        Returns:
+            bool: True if restream_token.json exists
+        """
+        return os.path.exists(self.restream_token_path)
+
+    def save_email_config(self, config: Dict[str, str]) -> None:
+        """Save email notification configuration.
+
+        Args:
+            config: Dict with connection_string, sender, recipient
+        """
+        assert os.path.basename(self.email_config_path) == "email_config.json"
+        fd = os.open(self.email_config_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "w") as f:
+            json.dump(config, f, indent=2)
+
+    def get_email_config(self) -> Optional[Dict[str, str]]:
+        """Load email notification configuration.
+
+        Returns:
+            Dict with email config, or None if not configured
+        """
+        if not os.path.exists(self.email_config_path):
+            return None
+        with open(self.email_config_path, "r") as f:
+            return json.load(f)

--- a/youtube_updater/exceptions/custom_exceptions.py
+++ b/youtube_updater/exceptions/custom_exceptions.py
@@ -16,4 +16,8 @@ class TitleManagerError(YouTubeUpdaterError):
 
 class ConfigError(YouTubeUpdaterError):
     """Exception raised for configuration related errors."""
+    pass
+
+class RestreamAPIError(YouTubeUpdaterError):
+    """Exception raised for Restream API related errors."""
     pass 


### PR DESCRIPTION
## Summary
- Add `requests>=2.28.0` and `azure-communication-email>=1.0.0` to requirements.txt
- Extend `ConfigManager` with Restream token path and email config methods
- Add `RestreamAPIError` exception class
- Email config written with 0o600 permissions (contains ACS connection string)
- NF4 safeguard: all new operations verified to never touch YouTube auth files

Closes #49 (NF3), closes #50 (NF4)
Part of #28 (Phase 1), #26 (Epic)

## Gate 1 Checklist
- [x] `pip install -r requirements.txt` succeeds
- [x] `pytest tests/unit/test_config_manager.py` -- 13 tests pass (8 new)
- [x] `pytest tests/unit/test_nf4_safeguard.py` -- 4 tests pass
- [x] `pytest tests/integration/test_config_restream.py` -- 5 tests pass
- [x] `pytest tests/smoke/` -- 32 existing tests pass
- [x] `pytest tests/acceptance/test_nf.py::test_nf3` -- pass
- [x] `pytest tests/acceptance/test_nf.py::test_nf4` -- pass
- [x] `pytest tests/ -v` -- 163 passed, 1 skipped, 16 xfailed
- [ ] CI green

## Test plan
- [x] All new ConfigManager methods tested (unit + integration)
- [x] NF4 safeguard verifies YouTube auth files untouched after every config operation
- [x] Email config file has 0o600 permissions
- [x] No regressions in existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)