### PR TITLE
Fix code review findings for Phase 1

### DIFF
--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -102,3 +102,26 @@ def test_save_email_config_sets_0o600_permissions(tmp_path):
     email_path = tmp_path / "email_config.json"
     mode = stat.S_IMODE(os.stat(email_path).st_mode)
     assert mode == 0o600, f"Expected 0o600 but got {oct(mode)}"
+
+
+def test_save_email_config_raises_on_tampered_path(tmp_path):
+    from youtube_updater.exceptions.custom_exceptions import ConfigError
+    cm = ConfigManager(str(tmp_path))
+    cm.email_config_path = str(tmp_path / "token.json")
+    with pytest.raises(ConfigError):
+        cm.save_email_config({"connection_string": "x", "sender": "a", "recipient": "b"})
+
+
+def test_get_email_config_raises_on_corrupt_json(tmp_path):
+    from youtube_updater.exceptions.custom_exceptions import ConfigError
+    cm = ConfigManager(str(tmp_path))
+    with open(tmp_path / "email_config.json", "w") as f:
+        f.write("{corrupt json")
+    with pytest.raises(ConfigError, match="corrupt"):
+        cm.get_email_config()
+
+
+def test_get_file_paths_includes_email_config(tmp_path):
+    cm = ConfigManager(str(tmp_path))
+    paths = cm.get_file_paths()
+    assert "email_config_path" in paths

--- a/youtube_updater/core/config_manager.py
+++ b/youtube_updater/core/config_manager.py
@@ -3,6 +3,7 @@ import os
 from pathlib import Path
 from typing import Dict, Optional
 import platformdirs
+from ..exceptions.custom_exceptions import ConfigError
 from ..utils.file_operations import FileOperations
 
 class ConfigManager:
@@ -54,6 +55,7 @@ class ConfigManager:
             "client_secrets_path": self.client_secrets_path,
             "history_log": self.history_log,
             "restream_token_path": self.restream_token_path,
+            "email_config_path": self.email_config_path,
         }
     
     def ensure_client_secrets(self) -> bool:
@@ -94,7 +96,10 @@ class ConfigManager:
         Args:
             config: Dict with connection_string, sender, recipient
         """
-        assert os.path.basename(self.email_config_path) == "email_config.json"
+        if os.path.basename(self.email_config_path) != "email_config.json":
+            raise ConfigError(
+                f"Refusing to write: unexpected email config path '{self.email_config_path}'"
+            )
         fd = os.open(self.email_config_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
         with os.fdopen(fd, "w") as f:
             json.dump(config, f, indent=2)
@@ -107,5 +112,8 @@ class ConfigManager:
         """
         if not os.path.exists(self.email_config_path):
             return None
-        with open(self.email_config_path, "r") as f:
-            return json.load(f)
+        try:
+            with open(self.email_config_path, "r") as f:
+                return json.load(f)
+        except json.JSONDecodeError as e:
+            raise ConfigError(f"email_config.json is corrupt: {e}") from e


### PR DESCRIPTION
## Summary
Addresses code review findings from the Phase 1 review:

- Replace `assert` guard in `save_email_config` with `ConfigError` raise (assert is stripped by `python -O`)
- Add `json.JSONDecodeError` handling in `get_email_config` wrapping as `ConfigError`
- Add `email_config_path` to `get_file_paths()` dict for consistency
- Add 3 new tests: tampered path rejection, corrupt JSON handling, email_config in paths

Part of #28 (Phase 1), #26 (Epic)

## Test plan
- [x] `pytest tests/ -v` -- 166 passed, 1 skipped, 16 xfailed

🤖 Generated with [Claude Code](https://claude.com/claude-code)